### PR TITLE
refactor: Store darkmode styling configuration in css

### DIFF
--- a/compiled/style.css
+++ b/compiled/style.css
@@ -2,11 +2,17 @@
 @font-face { font-family: 'crimsonPro-regular'; src: url('CrimsonPro-Regular.ttf'); } 
 
 :root {
-    --background-col: black;
-    --focusedText-col: black;
+    --background-col: #0C1317;
+    --focusedText-col: #CEB591;
     --focusedTint-col: invert(82%) sepia(38%) saturate(248%) hue-rotate(353deg) brightness(83%) contrast(93%);
-    --unfocusedText-col: black;
+    --unfocusedText-col: #8A836B;
     font-family: 'cascadia-code';
+}
+:root.light {
+    --background-col: #D4C5A8;
+    --focusedText-col: #6B1A40;
+    --focusedTint-col: invert(12%) sepia(61%) saturate(2130%) hue-rotate(304deg) brightness(89%) contrast(100%);
+    --unfocusedText-col: #A74D68;
 }
 
 

--- a/compiled/theme.js
+++ b/compiled/theme.js
@@ -1,4 +1,3 @@
-
 // Sets up correct theme
 function storageAvailable(type) {
     var storage;
@@ -14,65 +13,32 @@ function storageAvailable(type) {
     }
 }
 
-var theme = "dark";
+function setTheme(theme) {
+    storage = storageAvailable("localStorage");
+    if(storage) storage.setItem("theme", theme);
 
-if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
-    theme = "light";
+    if (theme == "dark") {
+        document.getElementById("theme").setAttribute("src", "moon.svg")
+        document.documentElement.classList.remove("light");
+    } else {
+        document.getElementById("theme").setAttribute("src", "sun.svg")
+        document.documentElement.classList.add("light");
+    }
 }
+
+var theme = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches
+    ? "dark"
+    : "light";
 
 storage = storageAvailable("localStorage");
 if (storage) {
-    theme = storage.getItem("theme") ? storage.getItem("theme"): theme;
+    theme = storage.getItem("theme") ?? theme;
 } 
 
+// Initialize theme
+setTheme(theme);
 
-// Now actually use correct theme and make it receptive to clicks
-document.getElementById("theme").addEventListener("click", themeToggle);
-
-if (theme == "dark") {
-    document.getElementById("theme").setAttribute("src", "moon.svg")
-    document.documentElement.style.setProperty("--background-col", "#0C1317");
-    document.documentElement.style.setProperty("--focusedText-col", "#CEB591");
-    document.documentElement.style.setProperty("--focusedTint-col", "invert(82%) sepia(38%) saturate(248%) hue-rotate(353deg) brightness(83%) contrast(93%)")
-    document.documentElement.style.setProperty("--unfocusedText-col", "#8A836B");
-} else {
-    document.getElementById("theme").setAttribute("src", "sun.svg")
-    document.documentElement.style.setProperty("--background-col", "#D4C5A8");
-    document.documentElement.style.setProperty("--focusedText-col", "#6B1A40");
-    document.documentElement.style.setProperty("--focusedTint-col", "invert(12%) sepia(61%) saturate(2130%) hue-rotate(304deg) brightness(89%) contrast(100%)")
-    document.documentElement.style.setProperty("--unfocusedText-col", "#A74D68");
-}
-
-
-// Text colour
-// Unselected text Colour
-// Background Colour
-
-function themeToggle(event) {
-    storage = storageAvailable("localStorage");
-    if (theme == "light") {
-        theme = "dark";
-        if (storage) {
-            storage.setItem("theme", "dark");
-        }
-        // Actually set to dark theme
-        document.getElementById("theme").setAttribute("src", "moon.svg")
-        document.documentElement.style.setProperty("--background-col", "#0C1317");
-        document.documentElement.style.setProperty("--focusedText-col", "#CEB591");
-        document.documentElement.style.setProperty("--focusedTint-col", "invert(82%) sepia(38%) saturate(248%) hue-rotate(353deg) brightness(83%) contrast(93%)")
-        document.documentElement.style.setProperty("--unfocusedText-col", "#8A836B");
-
-
-    } else {
-        theme = "light";
-        if (storage) {
-            storage.setItem("theme", "light");
-        }
-        // Actually set to light theme
-        document.getElementById("theme").setAttribute("src", "sun.svg")
-        document.documentElement.style.setProperty("--background-col", "#D4C5A8");
-        document.documentElement.style.setProperty("--focusedText-col", "#6B1A40");
-        document.documentElement.style.setProperty("--focusedTint-col", "invert(12%) sepia(61%) saturate(2130%) hue-rotate(304deg) brightness(89%) contrast(100%)")
-        document.documentElement.style.setProperty("--unfocusedText-col", "#A74D68");
-    }
-}
+document.getElementById("theme").addEventListener("click", () => {
+    theme = theme === "light" ? "dark" : "light";
+    setTheme(theme);
+});


### PR DESCRIPTION
## Proposed Changes
 - Refactors `theme.js` and stores dark mode styling in css only. Javascript is only used to toggle between which set of variables to use.
 - Slightly refactored javascript to prevent duplication of `setTheme` logic